### PR TITLE
Option to ignore FITS Timespamps and sort by filename

### DIFF
--- a/Tangra 3/Controller/VideoController.cs
+++ b/Tangra 3/Controller/VideoController.cs
@@ -251,16 +251,20 @@ namespace Tangra.Controller
                 var frm = new frmSortFitsFiles(this);
                 frm.SetFiles(fitsFiles);
                 frm.StartPosition = FormStartPosition.CenterParent;
-                frm.ShowDialog(m_MainForm);
-                if (!string.IsNullOrWhiteSpace(frm.ErrorMessage))
+
+                if (frm.ShowDialog(m_MainForm) == DialogResult.OK)
                 {
-                    ShowMessageBox(frm.ErrorMessage, "Tangra", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return false;
+                    if (!string.IsNullOrWhiteSpace(frm.ErrorMessage))
+                    {
+                        ShowMessageBox(frm.ErrorMessage, "Tangra", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return false;
+                    }
+                    fitsFiles = frm.GetSortedFiles();
+
+                    return OpenFitsFileSequence(folderName, fitsFiles, frm.TimeStampReader, frm.BitPix, frm.NegPixCorrection, frm.FlipVertically, frm.FlipHorizontally);
                 }
-
-                fitsFiles = frm.GetSortedFiles();
-
-                return OpenFitsFileSequence(folderName, fitsFiles, frm.TimeStampReader, frm.BitPix, frm.NegPixCorrection, frm.FlipVertically, frm.FlipHorizontally);
+                else
+                    return false;
             }
 	    }
 

--- a/Tangra 3/Video/FITS/frmChooseTimeHeaders.Designer.cs
+++ b/Tangra 3/Video/FITS/frmChooseTimeHeaders.Designer.cs
@@ -40,13 +40,14 @@
             this.label3 = new System.Windows.Forms.Label();
             this.cbxExposure = new System.Windows.Forms.ComboBox();
             this.cbxExposureUnits = new System.Windows.Forms.ComboBox();
-            this.ucTimestampControl2 = new Tangra.Video.FITS.ucFitsTimeStampConfigurator();
-            this.ucTimestampControl = new Tangra.Video.FITS.ucFitsTimeStampConfigurator();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
             this.btnPixelValueMapping = new System.Windows.Forms.Button();
             this.cbxFlipHorizontally = new System.Windows.Forms.CheckBox();
             this.cbxFlipVertically = new System.Windows.Forms.CheckBox();
+            this.rbNoTimestamp = new System.Windows.Forms.RadioButton();
+            this.ucTimestampControl2 = new Tangra.Video.FITS.ucFitsTimeStampConfigurator();
+            this.ucTimestampControl = new Tangra.Video.FITS.ucFitsTimeStampConfigurator();
             this.groupBox1.SuspendLayout();
             this.pnlExposure.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pbxExposureWarning)).BeginInit();
@@ -68,7 +69,7 @@
             // rbStartEndTimestamp
             // 
             this.rbStartEndTimestamp.AutoSize = true;
-            this.rbStartEndTimestamp.Location = new System.Drawing.Point(207, 18);
+            this.rbStartEndTimestamp.Location = new System.Drawing.Point(165, 18);
             this.rbStartEndTimestamp.Name = "rbStartEndTimestamp";
             this.rbStartEndTimestamp.Size = new System.Drawing.Size(137, 17);
             this.rbStartEndTimestamp.TabIndex = 2;
@@ -179,21 +180,6 @@
             this.cbxExposureUnits.TabIndex = 10;
             this.cbxExposureUnits.SelectedIndexChanged += new System.EventHandler(this.cbxExposureUnits_SelectedIndexChanged);
             // 
-            // ucTimestampControl2
-            // 
-            this.ucTimestampControl2.Location = new System.Drawing.Point(6, 170);
-            this.ucTimestampControl2.Name = "ucTimestampControl2";
-            this.ucTimestampControl2.Size = new System.Drawing.Size(434, 134);
-            this.ucTimestampControl2.TabIndex = 8;
-            this.ucTimestampControl2.Visible = false;
-            // 
-            // ucTimestampControl
-            // 
-            this.ucTimestampControl.Location = new System.Drawing.Point(7, 19);
-            this.ucTimestampControl.Name = "ucTimestampControl";
-            this.ucTimestampControl.Size = new System.Drawing.Size(434, 134);
-            this.ucTimestampControl.TabIndex = 7;
-            // 
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
@@ -244,11 +230,39 @@
             this.cbxFlipVertically.Text = "Flip Vertically";
             this.cbxFlipVertically.UseVisualStyleBackColor = true;
             // 
+            // rbNoTimestamp
+            // 
+            this.rbNoTimestamp.AutoSize = true;
+            this.rbNoTimestamp.Location = new System.Drawing.Point(320, 18);
+            this.rbNoTimestamp.Name = "rbNoTimestamp";
+            this.rbNoTimestamp.Size = new System.Drawing.Size(138, 17);
+            this.rbNoTimestamp.TabIndex = 76;
+            this.rbNoTimestamp.TabStop = true;
+            this.rbNoTimestamp.Text = "None (Sort by Filename)";
+            this.rbNoTimestamp.UseVisualStyleBackColor = true;
+            this.rbNoTimestamp.CheckedChanged += new System.EventHandler(this.rbNoTimestamp_CheckedChanged);
+            // 
+            // ucTimestampControl2
+            // 
+            this.ucTimestampControl2.Location = new System.Drawing.Point(7, 170);
+            this.ucTimestampControl2.Name = "ucTimestampControl2";
+            this.ucTimestampControl2.Size = new System.Drawing.Size(434, 134);
+            this.ucTimestampControl2.TabIndex = 8;
+            this.ucTimestampControl2.Visible = false;
+            // 
+            // ucTimestampControl
+            // 
+            this.ucTimestampControl.Location = new System.Drawing.Point(7, 19);
+            this.ucTimestampControl.Name = "ucTimestampControl";
+            this.ucTimestampControl.Size = new System.Drawing.Size(434, 134);
+            this.ucTimestampControl.TabIndex = 7;
+            // 
             // frmChooseTimeHeaders
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(475, 429);
+            this.Controls.Add(this.rbNoTimestamp);
             this.Controls.Add(this.cbxFlipHorizontally);
             this.Controls.Add(this.cbxFlipVertically);
             this.Controls.Add(this.btnPixelValueMapping);
@@ -291,5 +305,6 @@
         private System.Windows.Forms.Button btnPixelValueMapping;
         protected internal System.Windows.Forms.CheckBox cbxFlipHorizontally;
         protected internal System.Windows.Forms.CheckBox cbxFlipVertically;
+        private System.Windows.Forms.RadioButton rbNoTimestamp;
     }
 }

--- a/Tangra 3/Video/FITS/frmChooseTimeHeaders.cs
+++ b/Tangra 3/Video/FITS/frmChooseTimeHeaders.cs
@@ -44,7 +44,7 @@ namespace Tangra.Video.FITS
 
         public bool HasNegativePixels { get; private set; }
 
-        public int BitPix { get; private set; }
+        public int BitPix { get; private set; }       
 
         public frmChooseTimeHeaders()
         {
@@ -285,6 +285,15 @@ namespace Tangra.Video.FITS
                 DialogResult = DialogResult.OK;
                 Close();
             }
+            else
+            {
+                FlipVertically = cbxFlipVertically.Checked;
+                FlipHorizontally = cbxFlipHorizontally.Checked;
+
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+
         }
 
         private void rbStartEndTimestamp_CheckedChanged(object sender, EventArgs e)
@@ -325,5 +334,15 @@ namespace Tangra.Video.FITS
         {
             ReviewPixelMapping();
         }
+
+        private void rbNoTimestamp_CheckedChanged(object sender, EventArgs e)
+        {
+            bool enabled = !rbNoTimestamp.Checked;
+            ucTimestampControl2.Enabled = enabled;
+            ucTimestampControl.Enabled = enabled;
+            pnlExposure.Enabled = enabled;
+
+        }
+        
     }
 }

--- a/Tangra 3/Video/FITS/frmSortFitsFiles.cs
+++ b/Tangra 3/Video/FITS/frmSortFitsFiles.cs
@@ -210,8 +210,8 @@ namespace Tangra.Video.FITS
             m_SortedByTimeStamp = true;
             if (m_FilesWithExposure == 0 && m_FilesWithoutExposure > 0)
             {
-                // No longer need this warning - it is handled by FITS Time Headers Dialog
-                //MessageBox.Show("None of the FITS files have a saved exposure and they have been ordered by file name!", "Tangra", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                // Not sorting by timestamp and using filenames instead, because
+                // FITS heades were set to be ignored by the user in the Choose FITS Headers dialog
                 m_SortedByTimeStamp = false;
             }
             else if (m_FilesWithExposure > 0 && m_FilesWithoutExposure > 0)

--- a/Tangra 3/Video/FITS/frmSortFitsFiles.cs
+++ b/Tangra 3/Video/FITS/frmSortFitsFiles.cs
@@ -98,6 +98,29 @@ namespace Tangra.Video.FITS
 
         private void frmSortFitsFiles_Shown(object sender, EventArgs e)
         {
+            if (m_FitsFiles.Length > 0)
+            {
+                var frm = new frmChooseTimeHeaders(m_FitsFiles[0], GetOrderedFitsFileHash(), m_VideoController);
+                if (frm.ShowDialog(this) == DialogResult.OK)
+                {
+                    TimeStampReader = frm.TimeStampReader;
+                    FlipVertically = frm.FlipVertically;
+                    FlipHorizontally = frm.FlipHorizontally;
+                    MinPixelValue = frm.MinPixelValue;
+                    MaxPixelValue = frm.MaxPixelValue;
+                    BitPix = frm.BitPix;
+                    NegPixCorrection = frm.NegPixCorrection;
+                }
+                else
+                {
+                    Array.Clear(m_FitsFiles, 0, m_FitsFiles.Length);
+                    DialogResult = DialogResult.Cancel;
+                    Close();
+                    return;
+                }
+            }
+
+
             m_FitsHeaders = new Header[m_FitsFiles.Length];
             m_FitsTimestamps = new DateTime?[m_FitsFiles.Length];
 
@@ -107,7 +130,7 @@ namespace Tangra.Video.FITS
 
             var fileSizeInfo = new Dictionary<string, FitsFileFormatInfoRecord>();
             TimeStampReader = null;
-
+                                  
             for (int i = 0; i < m_FitsFiles.Length; i++)
             {
                 try
@@ -132,30 +155,17 @@ namespace Tangra.Video.FITS
                         bool isMidPoint;
                         double? fitsExposure = null;
                         DateTime? timestamp = null;
-
-                        if (i == 0)
+                        
+                        if (TimeStampReader != null)
                         {
-                            var frm = new frmChooseTimeHeaders(m_FitsFiles[i], GetOrderedFitsFileHash(), m_VideoController);
-                            if (frm.ShowDialog(this) == DialogResult.OK)
+                            try
                             {
-                                TimeStampReader = frm.TimeStampReader;
-                                FlipVertically = frm.FlipVertically;
-                                FlipHorizontally = frm.FlipHorizontally;
+                                timestamp = FITSHelper2.ParseExposure(m_FitsFiles[i], hdr, TimeStampReader, out isMidPoint, out fitsExposure);
                             }
-
-                            MinPixelValue = frm.MinPixelValue;
-                            MaxPixelValue = frm.MaxPixelValue;
-                            BitPix = frm.BitPix;
-                            NegPixCorrection = frm.NegPixCorrection;
-                        }
-
-                        try
-                        {
-                            timestamp = FITSHelper2.ParseExposure(m_FitsFiles[i], hdr, TimeStampReader, out isMidPoint, out fitsExposure);
-                        }
-                        catch (Exception ex)
-                        {
-                            Trace.WriteLine(ex.ToString());
+                            catch (Exception ex)
+                            {
+                                Trace.WriteLine(ex.ToString());
+                            }
                         }
 
                         m_FitsTimestamps[i] = timestamp;
@@ -200,12 +210,13 @@ namespace Tangra.Video.FITS
             m_SortedByTimeStamp = true;
             if (m_FilesWithExposure == 0 && m_FilesWithoutExposure > 0)
             {
-                MessageBox.Show("None of the FITS files have a saved exposure and they have been ordered by file name!", "Tangra", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                // No longer need this warning - it is handled by FITS Time Headers Dialog
+                //MessageBox.Show("None of the FITS files have a saved exposure and they have been ordered by file name!", "Tangra", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 m_SortedByTimeStamp = false;
             }
             else if (m_FilesWithExposure > 0 && m_FilesWithoutExposure > 0)
                 MessageBox.Show(string.Format("{0} out of {1} of the FITS files have a missing exposure (checked headers: EXPOSURE, EXPTIME and RAWTIME). Please treat the reported timestamps with suspicion and expect inconsistencies.", m_FilesWithoutExposure, m_FilesWithoutExposure + m_FilesWithExposure), "Tangra", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-
+            DialogResult = DialogResult.OK;
             Close();
         }
     }


### PR DESCRIPTION
Added an option to ignore FITS timestamps  in frmSortFitsFiles and sort the files in a sequence by filename instead