### PR TITLE
NOISSUE extended exposure time range to avoid a crash for long exposures (more than 1s)

### DIFF
--- a/Tangra 3/Video/SER/frmSerTimestampExposure.Designer.cs
+++ b/Tangra 3/Video/SER/frmSerTimestampExposure.Designer.cs
@@ -86,7 +86,7 @@
             this.nudExposureMs.DecimalPlaces = 2;
             this.nudExposureMs.Location = new System.Drawing.Point(108, 3);
             this.nudExposureMs.Maximum = new decimal(new int[] {
-            1000,
+            60000,
             0,
             0,
             0});
@@ -94,7 +94,7 @@
             this.nudExposureMs.Size = new System.Drawing.Size(69, 20);
             this.nudExposureMs.TabIndex = 21;
             this.nudExposureMs.Value = new decimal(new int[] {
-            25,
+            0,
             0,
             0,
             0});


### PR DESCRIPTION
Hi Hristo,

this was reported by Gerhard Dangl while testing the timing accuracy of our camera prototype. He noticed Tangra crashes for exposure times greater than 1s.

cheers,
Andreas