### PR TITLE
status popup and image overlay astro analogue video bug

### DIFF
--- a/Tangra 3/Controller/LightCurveContext.cs
+++ b/Tangra 3/Controller/LightCurveContext.cs
@@ -86,7 +86,8 @@ namespace Tangra.Controller
 		private int m_Binning = 0;
 	    private int m_BinningFirstFrame = 0;
 		private int m_Normalisation = -1;
-		private FilterType m_Filter = FilterType.NoFilter;
+        private bool[] m_Normalisations = new bool[4];
+        private FilterType m_Filter = FilterType.NoFilter;
 		private NormalisationMethod m_NormMethod = NormalisationMethod.Average4Frame;
 		private float[] m_ReProcessApertures = new float[4];
 		private int[] m_ReProcessFitAreas = new int[4];
@@ -102,7 +103,7 @@ namespace Tangra.Controller
 		public uint MinFrame;
 		public uint MaxFrame;
 		public int ObjectCount;
-
+        
 		public uint m_SelectedFrameNo = 0;
 
 		private XAxisMode m_XAxisMode;
@@ -140,6 +141,7 @@ namespace Tangra.Controller
 		private ProcessingType m_bu_ProcessingType = ProcessingType.SignalMinusBackground;
 		private int m_bu_Binning = 0;
 		private int m_bu_Normalisation = -1;
+        private bool[] m_bu_Normalisations = new bool[4];
 		private FilterType m_bu_Filter = FilterType.NoFilter;
 		private NormalisationMethod mbu__NormMethod = NormalisationMethod.Average4Frame;
 		private float[] m_bu_ReProcessApertures = new float[4];
@@ -155,7 +157,10 @@ namespace Tangra.Controller
 			m_bu_ProcessingType = m_ProcessingType;
 			m_bu_Binning = m_Binning;
 			m_bu_Normalisation = m_Normalisation;
-			m_bu_Filter = m_Filter;
+            for (int i = 0; i < 4; i++)
+                m_bu_Normalisations[i] = m_Normalisations[i];
+
+            m_bu_Filter = m_Filter;
 			mbu__NormMethod = m_NormMethod;
 			bu_SelectedFrameNo = SelectedFrameNo;
 
@@ -178,7 +183,10 @@ namespace Tangra.Controller
 			m_ProcessingType = m_bu_ProcessingType;
 			m_Binning = m_bu_Binning;
 			m_Normalisation = m_bu_Normalisation;
-			m_Filter = m_bu_Filter;
+            for (int i = 0; i < 4; i++)
+                m_Normalisations[i] = m_bu_Normalisations[i];
+
+            m_Filter = m_bu_Filter;
 			m_NormMethod = mbu__NormMethod;
 			SelectedFrameNo = bu_SelectedFrameNo;
 
@@ -313,6 +321,11 @@ namespace Tangra.Controller
 			}
 		}
 
+        public bool[] Normalisations
+        {
+            get { return m_Normalisations; }
+        }
+
 		public FilterType Filter
 		{
 			get { return m_Filter; }
@@ -327,7 +340,7 @@ namespace Tangra.Controller
 			}
 		}
 
-		public NormalisationMethod NormMethod
+        public NormalisationMethod NormMethod
 		{
 			get { return m_NormMethod; }
 			set
@@ -335,7 +348,7 @@ namespace Tangra.Controller
 				if (m_NormMethod != value)
 				{
 					m_NormMethod = value;
-					// If the normalization is specified, changing the method will make the data durty
+					// If the normalization is specified, changing the method will make the data dirty
 					m_Dirty = m_Normalisation > -1;
 				}
 			}

--- a/Tangra 3/Controller/VideoController.cs
+++ b/Tangra 3/Controller/VideoController.cs
@@ -2234,7 +2234,7 @@ namespace Tangra.Controller
 
 		private void ToggleAstroVideoStatusForm(bool forceShow)
 		{
-			if (IsAstroDigitalVideo)
+			if (IsAstroDigitalVideo && !IsAstroAnalogueVideo)
 			{
 				HideAavStatusForm();
 

--- a/Tangra 3/Video/AstroDigitalVideo/AdvOverlayManager.cs
+++ b/Tangra 3/Video/AstroDigitalVideo/AdvOverlayManager.cs
@@ -69,7 +69,7 @@ namespace Tangra.Video.AstroDigitalVideo
                 if (m_CurrentImageWidth != currentImage.Width)
                     ComputeFontSizeAndTimeStampPosition(g, currentImage.Width, currentImage.Height);
 
-				if (isAstroDigitalVideo)
+				if (isAstroDigitalVideo && !isAstroAnalogueVideo)
                     OverlayADVState(g, currentImage, state, context);	
 				else if (isAstroAnalogueVideo)
                     OverlayAAVState(g, currentImage, state, context);

--- a/Tangra 3/VideoOperations/LightCurves/frmLightCurve.Computations.cs
+++ b/Tangra 3/VideoOperations/LightCurves/frmLightCurve.Computations.cs
@@ -269,44 +269,84 @@ namespace Tangra.VideoOperations.LightCurves
 
         private void PerformNormalization()
         {
+            // Calculate the normalisation factor for each star chosen as a normalisation star
+            // and then calculate the normalisation factor averaged over all normalisation stars.
+
             List<double> normalIndexes = new List<double>();
+            List<double> averagedNormalIndexes = new List<double>();
 
-            switch(m_LightCurveController.Context.NormMethod)
+            int numberOfNormalisationStars = 0;
+
+            for (int starIndx = 0; starIndx < m_Header.ObjectCount; starIndx++)
             {
-                case LightCurveContext.NormalisationMethod.LinearFit:
-                    if (m_LightCurveController.Context.Binning > 0)
-                        PerformLinearFitBinnedNormalisation(ref normalIndexes);
-                    else
-                        PerformLinearFitReadingsNormalisation(ref normalIndexes);
-                    break;
+                
+                if (!m_LightCurveController.Context.Normalisations[starIndx]) continue;
 
-                case LightCurveContext.NormalisationMethod.FrameByFrame:
-                    if (m_LightCurveController.Context.Binning > 0)
-                        PerformAverageBinnedNormalisation(ref normalIndexes, 1);
-                    else
-                        PerformAverageReadingsNormalisation(ref normalIndexes, 1);
-                    break;
+                normalIndexes.Clear();
 
-                case LightCurveContext.NormalisationMethod.Average4Frame:
-                    if (m_LightCurveController.Context.Binning > 0)
-                        PerformAverageBinnedNormalisation(ref normalIndexes, 4);
-                    else
-                        PerformAverageReadingsNormalisation(ref normalIndexes, 4);
-                    break;
+                numberOfNormalisationStars++;
 
-				case LightCurveContext.NormalisationMethod.Average8Frame:
-					if (m_LightCurveController.Context.Binning > 0)
-						PerformAverageBinnedNormalisation(ref normalIndexes, 8);
-					else
-						PerformAverageReadingsNormalisation(ref normalIndexes, 8);
-					break;
+                m_LightCurveController.Context.Normalisation = starIndx;
 
-                case LightCurveContext.NormalisationMethod.Average16Frame:
-                    if (m_LightCurveController.Context.Binning > 0)
-                        PerformAverageBinnedNormalisation(ref normalIndexes, 16);
-                    else
-                        PerformAverageReadingsNormalisation(ref normalIndexes, 16);
-                    break;
+                switch (m_LightCurveController.Context.NormMethod)
+                {
+                    case LightCurveContext.NormalisationMethod.LinearFit:
+                        if (m_LightCurveController.Context.Binning > 0)
+                            PerformLinearFitBinnedNormalisation(ref normalIndexes);
+                        else
+                            PerformLinearFitReadingsNormalisation(ref normalIndexes);
+                        break;
+
+                    case LightCurveContext.NormalisationMethod.FrameByFrame:
+                        if (m_LightCurveController.Context.Binning > 0)
+                            PerformAverageBinnedNormalisation(ref normalIndexes, 1);
+                        else
+                            PerformAverageReadingsNormalisation(ref normalIndexes, 1);
+                        break;
+
+                    case LightCurveContext.NormalisationMethod.Average4Frame:
+                        if (m_LightCurveController.Context.Binning > 0)
+                            PerformAverageBinnedNormalisation(ref normalIndexes, 4);
+                        else
+                            PerformAverageReadingsNormalisation(ref normalIndexes, 4);
+                        break;
+
+                    case LightCurveContext.NormalisationMethod.Average8Frame:
+                        if (m_LightCurveController.Context.Binning > 0)
+                            PerformAverageBinnedNormalisation(ref normalIndexes, 8);
+                        else
+                            PerformAverageReadingsNormalisation(ref normalIndexes, 8);
+                        break;
+
+                    case LightCurveContext.NormalisationMethod.Average16Frame:
+                        if (m_LightCurveController.Context.Binning > 0)
+                            PerformAverageBinnedNormalisation(ref normalIndexes, 16);
+                        else
+                            PerformAverageReadingsNormalisation(ref normalIndexes, 16);
+                        break;
+                }
+
+                if (numberOfNormalisationStars == 1)
+                {
+                    for (int indx = 0; indx < normalIndexes.Count; indx++)
+                    {
+                        averagedNormalIndexes.Add(normalIndexes[indx]);
+                    }
+                }
+                else
+                {
+                    for (int indx = 0; indx < normalIndexes.Count; indx++)
+                    {
+                        averagedNormalIndexes[indx] = averagedNormalIndexes[indx] + normalIndexes[indx];
+                    }
+                }
+
+            }
+
+            // calculate the normalisation factor averaged over all the normalisation stars
+            for (int indx = 0; indx < normalIndexes.Count; indx++)
+            {
+                normalIndexes[indx] = averagedNormalIndexes[indx] / numberOfNormalisationStars;
             }
 
             int minValue = int.MaxValue;

--- a/Tangra 3/VideoOperations/LightCurves/frmLightCurve.cs
+++ b/Tangra 3/VideoOperations/LightCurves/frmLightCurve.cs
@@ -975,11 +975,6 @@ namespace Tangra.VideoOperations.LightCurves
 
         private void NormalizationMenuItemChecked(object sender, EventArgs e)
         {
-            // Remove the checkbox from the sub menu items
-            DrawColoredRectangle(miNormalisation1, 0, true);
-            DrawColoredRectangle(miNormalisation2, 1, true);
-            DrawColoredRectangle(miNormalisation3, 2, true);
-            DrawColoredRectangle(miNormalisation4, 3, true);
 
             if (sender == miNoNormalization)
             {
@@ -992,62 +987,143 @@ namespace Tangra.VideoOperations.LightCurves
                 m_LightCurveController.Context.Normalisation = -1;
                 tslblNormalisation.Text = "No Normalisation";
                 tslblNormalisation.Image = null;
+
+                for (int i=0; i < m_Header.ObjectCount; i++)
+                {
+                    m_LightCurveController.Context.Normalisations[i] = false;
+                }
+
+                DrawColoredRectangle(miNormalisation1, 0, true);
+                DrawColoredRectangle(miNormalisation2, 1, true);
+                DrawColoredRectangle(miNormalisation3, 2, true);
+                DrawColoredRectangle(miNormalisation4, 3, true);
+
             }
             else if (sender == miNormalisation1)
             {
-                miNoNormalization.Checked = false;
-                miNormalisation1.Checked = true;
-                miNormalisation2.Checked = false;
-                miNormalisation3.Checked = false;
-                miNormalisation4.Checked = false;
+                // toggle the state of the normalisation star
+                m_LightCurveController.Context.Normalisations[0] ^= true;
 
-                m_LightCurveController.Context.Normalisation = 0;
-                tslblNormalisation.Text = "Normalised";
-                DrawColoredRectangle(tslblNormalisation, 0, true);
-                DrawColoredRectangleWithCheckBox(miNormalisation1, 0);
+                if (m_LightCurveController.Context.Normalisations[0])
+                {
+                    miNoNormalization.Checked = false;
+                    miNormalisation1.Checked = true;
+
+                    m_LightCurveController.Context.Normalisation = 0;
+                    tslblNormalisation.Text = "Normalised";
+
+                    DrawColoredRectangleWithCheckBox(miNormalisation1, 0);
+                }
+                else
+                {
+                    miNormalisation1.Checked = false;
+                    m_LightCurveController.Context.Normalisation = -1;
+                    DrawColoredRectangle(miNormalisation1, 0, true);
+                }
             }
             else if (sender == miNormalisation2)
             {
-                miNoNormalization.Checked = false;
-                miNormalisation1.Checked = false;
-                miNormalisation2.Checked = true;
-                miNormalisation3.Checked = false;
-                miNormalisation4.Checked = false;
+                m_LightCurveController.Context.Normalisations[1] ^= true;
 
-                m_LightCurveController.Context.Normalisation = 1;
-                tslblNormalisation.Text = "Normalised";
-                DrawColoredRectangle(tslblNormalisation, 1, true);
-                DrawColoredRectangleWithCheckBox(miNormalisation2, 1);
+
+                if (m_LightCurveController.Context.Normalisations[1])
+                {
+                    miNoNormalization.Checked = false;
+                    miNormalisation2.Checked = true;
+
+                    m_LightCurveController.Context.Normalisation = 1;
+                    tslblNormalisation.Text = "Normalised";
+
+                    DrawColoredRectangleWithCheckBox(miNormalisation2, 1);
+                }
+                else
+                {
+                    miNormalisation2.Checked = false;
+                    m_LightCurveController.Context.Normalisation = -1;
+                    DrawColoredRectangle(miNormalisation2, 1, true);
+                }
             }
             else if (sender == miNormalisation3)
             {
-                miNoNormalization.Checked = false;
-                miNormalisation1.Checked = false;
-                miNormalisation2.Checked = false;
-                miNormalisation3.Checked = true;
-                miNormalisation4.Checked = false;
+                m_LightCurveController.Context.Normalisations[2] ^= true;
 
-                m_LightCurveController.Context.Normalisation = 2;
-                tslblNormalisation.Text = "Normalised";
-                DrawColoredRectangle(tslblNormalisation, 2, true);
-                DrawColoredRectangleWithCheckBox(miNormalisation3, 2);
+                if (m_LightCurveController.Context.Normalisations[2])
+                {
+                    miNoNormalization.Checked = false;
+                    miNormalisation3.Checked = true;
+
+                    m_LightCurveController.Context.Normalisation = 2;
+                    tslblNormalisation.Text = "Normalised";
+
+                    DrawColoredRectangleWithCheckBox(miNormalisation3, 2);
+                }
+                else
+                {
+                    miNormalisation3.Checked = false;
+                    m_LightCurveController.Context.Normalisation = -1;
+                    DrawColoredRectangle(miNormalisation3, 2, true);
+                }
             }
             else if (sender == miNormalisation4)
             {
-                miNoNormalization.Checked = false;
-                miNormalisation1.Checked = false;
-                miNormalisation2.Checked = false;
-                miNormalisation3.Checked = false;
-                miNormalisation4.Checked = true;
+                m_LightCurveController.Context.Normalisations[3] ^= true;
 
-                m_LightCurveController.Context.Normalisation = 3;                
-                tslblNormalisation.Text = "Normalised";
-                DrawColoredRectangle(tslblNormalisation, 3, true);
-                DrawColoredRectangleWithCheckBox(miNormalisation4, 3);
+                if (m_LightCurveController.Context.Normalisations[3])
+                {
+                    miNoNormalization.Checked = false;
+                    miNormalisation4.Checked = true;
+
+                    m_LightCurveController.Context.Normalisation = 3;
+                    tslblNormalisation.Text = "Normalised";
+
+                    DrawColoredRectangleWithCheckBox(miNormalisation4, 3);
+                }
+                else
+                {
+                    miNormalisation4.Checked = false;
+                    m_LightCurveController.Context.Normalisation = -1;
+                    DrawColoredRectangle(miNormalisation4, 3, true);
+                }
             }
+
+            tsblDrawNormalisationImage();
 
             statusStrip1.Refresh();
             pnlChart.Invalidate();
+        }
+
+        private void tsblDrawNormalisationImage()
+        {
+            int numChecked = 0;
+            for (int i=0; i < m_Header.ObjectCount; i++)
+            {
+                if (m_LightCurveController.Context.Normalisations[i]) numChecked++;
+            }
+
+            if (numChecked > 0)
+            {
+                m_LightCurveController.Context.Normalisation = numChecked; // set to force the lightcurve to be redrawn
+                if (tslblNormalisation.Image == null) tslblNormalisation.Image = new Bitmap(16, 16);
+                DrawIncludedObjectImage(tslblNormalisation.Image, numChecked, m_LightCurveController.Context.Normalisations);
+            }
+            else
+            {
+                miNoNormalization.Checked = true;
+                miNormalisation1.Checked = false;
+                miNormalisation2.Checked = false;
+                miNormalisation3.Checked = false;
+                miNormalisation4.Checked = false;
+
+                m_LightCurveController.Context.Normalisation = -1;
+                tslblNormalisation.Text = "No Normalisation";
+                tslblNormalisation.Image = null;
+
+                DrawColoredRectangle(miNormalisation1, 0, true);
+                DrawColoredRectangle(miNormalisation2, 1, true);
+                DrawColoredRectangle(miNormalisation3, 2, true);
+                DrawColoredRectangle(miNormalisation4, 3, true);
+            }
+
         }
 
         private bool m_Reprocessing = false;
@@ -1138,34 +1214,7 @@ namespace Tangra.VideoOperations.LightCurves
             miNormalisation3.Checked = false;
             miNormalisation4.Checked = false;
 
-            switch (m_LightCurveController.Context.Normalisation)
-            {
-                case -1:
-                    miNoNormalization.Checked = true;
-                    tslblNormalisation.Text = "No Normalisation";
-                    tslblNormalisation.Image = null;
-                    break;
-                case 0:
-                    miNormalisation1.Checked = true;
-                    tslblNormalisation.Text = "Normalised";
-                    DrawColoredRectangle(tslblNormalisation, 0, true);
-                    break;
-                case 1:
-                    miNormalisation2.Checked = true;
-                    tslblNormalisation.Text = "Normalised";
-                    DrawColoredRectangle(tslblNormalisation, 1, true);
-                    break;
-                case 2:
-                    miNormalisation3.Checked = true;
-                    tslblNormalisation.Text = "Normalised";
-                    DrawColoredRectangle(tslblNormalisation, 2, true);
-                    break;
-                case 3:
-                    miNormalisation4.Checked = true;
-                    tslblNormalisation.Text = "Normalised";
-                    DrawColoredRectangle(tslblNormalisation, 3, true);
-                    break;
-            }
+            tsblDrawNormalisationImage();
 
             miNormalisation16DataPoints.Enabled = m_LightCurveController.Context.Normalisation >= 0;
             miNormalisation8DataPoints.Enabled = m_LightCurveController.Context.Normalisation >= 0;
@@ -1226,12 +1275,12 @@ namespace Tangra.VideoOperations.LightCurves
                 DrawColoredRectangleWithCheckBox(menuItems[i], i);
             }
 
-            DrawIncludedObjectImage(miIncludeObject.Image, numChecked);
+            DrawIncludedObjectImage(miIncludeObject.Image, numChecked, m_IncludeObjects);
             statusStrip1.Refresh();
             #endregion
         }
 
-        private void DrawIncludedObjectImage(Image img, int numObjects)
+        private void DrawIncludedObjectImage(Image img, int numObjects, bool[] includeObjects)
         {
             using(Graphics g = Graphics.FromImage(img))
             {
@@ -1241,7 +1290,7 @@ namespace Tangra.VideoOperations.LightCurves
                     {
                         for (int i = 0; i < 4; i++)
                         {
-                            if (m_IncludeObjects[i])
+                            if (includeObjects[i])
                             {
                                 g.Clear(m_DisplaySettings.TargetColors[i]);
                                 g.Save();
@@ -1254,7 +1303,7 @@ namespace Tangra.VideoOperations.LightCurves
                         int objDrawn = 0;
                         for (int i = 0; i < 4; i++)
                         {
-                            if (m_IncludeObjects[i])
+                            if (includeObjects[i])
                             {
                                 if (objDrawn == 0)
                                 {
@@ -1276,7 +1325,7 @@ namespace Tangra.VideoOperations.LightCurves
                         int objDrawn = 0;
                         for (int i = 0; i < 4; i++)
                         {
-                            if (m_IncludeObjects[i])
+                            if (includeObjects[i])
                             {
                                 if (objDrawn == 0)
                                 {
@@ -1305,7 +1354,7 @@ namespace Tangra.VideoOperations.LightCurves
                         int objDrawn = 0;
                         for (int i = 0; i < 4; i++)
                         {
-                            if (m_IncludeObjects[i])
+                            if (includeObjects[i])
                             {
                                 if (objDrawn == 0)
                                 {


### PR DESCRIPTION
Fix a minor bug where, when processing an AAV file, the image overlay and status popup are shown for the ADV rather than AAV.